### PR TITLE
Correct typo in tokenfield options parser

### DIFF
--- a/addon/components/input-tokenfield.js
+++ b/addon/components/input-tokenfield.js
@@ -27,7 +27,7 @@ export default Ember.TextField.extend({
     options = this._appendOption(options, 'delimiter');
     options = this._appendOption(options, 'beautify');
     options = this._appendOption(options, 'inputType');
-    options = this._appendOption(options, 'createTokenOnBlur');
+    options = this._appendOption(options, 'createTokensOnBlur');
     options = this._appendOption(options, 'typeahead');
     options = this._appendOption(options, 'tokens');
     options = this._appendOption(options, 'autocomplete');


### PR DESCRIPTION
## Issue

Input is not turning into tokens when tokenfield loses focus, even when setting the `createTokensOnBlur` option to `true`.
## Cause

There was a typo in the tokenfield options parser, namely the `createTokensOnBlur` option was written as `createTokenOnBlur`.
## Solution

Changing `createTokenOnBlur` to `createTokensOnBlur` in the tokenfield options parser, solves the problem.
