### PR TITLE
Exposes the element$ and keeps the tokens array updated

### DIFF
--- a/addon/components/input-tokenfield.js
+++ b/addon/components/input-tokenfield.js
@@ -45,14 +45,14 @@ export default Ember.TextField.extend({
 
     element$
         .on('tokenfield:createdtoken', function (e) {
-          context._createdToken(e)
-        })
+          context._createdToken(e);
+        });
     this.set('element$', element$);
     this._consumeAutocompletePromise();
     this._consumeTokensPromise();
   },
 
-  _createdToken: function (e) {
+  _createdToken: function () {
     let tokens = this.get('element$').tokenfield('getTokens');
     this.set('tokens', tokens);
   },

--- a/addon/components/input-tokenfield.js
+++ b/addon/components/input-tokenfield.js
@@ -52,7 +52,7 @@ export default Ember.TextField.extend({
     this._consumeTokensPromise();
   },
 
-  _createdToken: function () {
+  _createdToken: function ( ) {
     let tokens = this.get('element$').tokenfield('getTokens');
     this.set('tokens', tokens);
   },

--- a/addon/components/input-tokenfield.js
+++ b/addon/components/input-tokenfield.js
@@ -40,10 +40,21 @@ export default Ember.TextField.extend({
 
     var options = this._buildTokenfieldOptions();
 
+    let context = this;
     element$.tokenfield(options);
 
+    element$
+        .on('tokenfield:createdtoken', function (e) {
+          context._createdToken(e)
+        })
+    this.set('element$', element$);
     this._consumeAutocompletePromise();
     this._consumeTokensPromise();
+  },
+
+  _createdToken: function (e) {
+    let tokens = this.get('element$').tokenfield('getTokens');
+    this.set('tokens', tokens);
   },
 
   _consumeAutocompletePromise: function() {


### PR DESCRIPTION
This commit gives access to the jQuery element of the tokenField, enabling the developer to access events such as `tokenfield:createtoken`

It also keeps the tokens array updated when there is a change to the tokens’ content

In the the following case, `tokens` is an array that stays updated and `element$` is the jQuery object of the tokenField

```
{{input-tokenfield
    tokens=tokens
    element$ = element$
}}
```
